### PR TITLE
added gd php extension to dependecies list

### DIFF
--- a/en/requirements.md
+++ b/en/requirements.md
@@ -15,6 +15,7 @@ PHP Extensions
 --------------
  - BCMath
  - Ctype
+ - Gd
  - JSON
  - Mbstring
  - OpenSSL


### PR DESCRIPTION
Did this because running `composer install` gave the error (and installing php-gd fixed):

```
Loading composer repositories with package information
Installing dependencies (including require-dev) from lock file
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for phpoffice/phpspreadsheet 1.14.1 -> satisfiable by phpoffice/phpspreadsheet[1.14.1].
    - phpoffice/phpspreadsheet 1.14.1 requires ext-gd * -> the requested PHP extension gd is missing from your system.
  Problem 2
    - phpoffice/phpspreadsheet 1.14.1 requires ext-gd * -> the requested PHP extension gd is missing from your system.
    - maatwebsite/excel 3.1.22 requires phpoffice/phpspreadsheet ^1.14 -> satisfiable by phpoffice/phpspreadsheet[1.14.1].
    - Installation request for maatwebsite/excel 3.1.22 -> satisfiable by maatwebsite/excel[3.1.22].
```