### PR TITLE
Update email.md to make it clear SMTP not on Cloud

### DIFF
--- a/en/user-manual/settings/email.md
+++ b/en/user-manual/settings/email.md
@@ -6,4 +6,6 @@ Email settings page is located under **Settings** menu. On this page you can set
 - **Templates**: Customize the email content as you wish.
 - **Protocol**: Choose between sending mail to the host's email, or through an SMTP.
 
+Note: Sending via SMTP [is not available](https://akaunting.com/forum/discussion/general/smtp-on-cloud-instance) on the cloud hosted version.
+
 ![general email](_images/email.gif)


### PR DESCRIPTION
Im using cloud instance and followed these docs and spent time trying to setup SMTP.
Eventually I discovered that it cant be done on Cloud instance, 
per this forum post: https://akaunting.com/forum/discussion/general/smtp-on-cloud-instance

Updating the docs to make everyone's life easier.